### PR TITLE
Add support for installing to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Usage: gh-release-install [OPTIONS] REPOSITORY ASSET DESTINATION
       prometheus-{version}.linux-amd64.tar.gz
 
   The DESTINATION argument define the DESTINATION path for the downloaded
-  file. Note that DESTINATION may contain variables such as '{version}' or
-  '{tag}'.
+  file. If DESTINATION is a directory, then the asset name will be written as
+  the file name in the directory. Note that DESTINATION may contain variables
+  such as '{version}' or '{tag}'.
 
   Examples:
       /usr/local/bin/shfmt

--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Usage: gh-release-install [OPTIONS] REPOSITORY ASSET DESTINATION
       v2.28.1
 
   To track the version installed on the system, use the --version-file flag to
-  define the <filename> where the version should be saved. The default is not
-  to save this version file. Note that <filename> may contain variables such
-  as '{destination}'.
+  define the <filename> where the version should be saved.
+  The default is not to save this version file.
+  Note that <filename> may contain variables such as '{destination}'. Also note
+  that '{destination}' is the full path, including filename, to the asset (even
+  if DESTINATION provided in the commandline is a directory).
 
   Examples:
       --version-file /opt/versions/prometheus.version

--- a/e2e/install_test.py
+++ b/e2e/install_test.py
@@ -52,6 +52,29 @@ def test_installer_run_shfmt(tmp_path):
     assert installer.version_file.read_text() == "v3.3.1"
 
 
+def test_installer_run_shfmt_install_to_dir(tmp_path):
+    destination_file = tmp_path / "shfmt_v3.3.1_linux_amd64"
+    destination_dir = tmp_path
+
+    installer = GhReleaseInstall(
+        repository="mvdan/sh",
+        asset="shfmt_{tag}_linux_amd64",
+        destination=destination_dir,
+        version="v3.3.1",
+        version_file="{destination}.version",
+    )
+
+    installer.run()
+
+    assert destination_file.is_file()
+
+    output = check_output(f"{destination_file} -version", text=True, shell=True)
+    assert output == "v3.3.1\n"
+
+    assert installer.version_file.is_file()
+    assert installer.version_file.read_text() == "v3.3.1"
+
+
 def test_installer_run_loki(tmp_path):
     destination_file = tmp_path / "loki"
 

--- a/e2e/install_test.py
+++ b/e2e/install_test.py
@@ -48,8 +48,8 @@ def test_installer_run_shfmt(tmp_path):
     output = check_output(f"{destination_file} -version", text=True, shell=True)
     assert output == "v3.3.1\n"
 
-    assert installer.version_file.is_file()
-    assert installer.version_file.read_text() == "v3.3.1"
+    assert (tmp_path / "shfmt.version").is_file()
+    assert (tmp_path / "shfmt.version").read_text() == "v3.3.1"
 
 
 def test_installer_run_shfmt_install_to_dir(tmp_path):
@@ -71,8 +71,8 @@ def test_installer_run_shfmt_install_to_dir(tmp_path):
     output = check_output(f"{destination_file} -version", text=True, shell=True)
     assert output == "v3.3.1\n"
 
-    assert installer.version_file.is_file()
-    assert installer.version_file.read_text() == "v3.3.1"
+    assert (tmp_path / "shfmt_v3.3.1_linux_amd64.version").is_file()
+    assert (tmp_path / "shfmt_v3.3.1_linux_amd64.version").read_text() == "v3.3.1"
 
 
 def test_installer_run_loki(tmp_path):

--- a/gh_release_install/cli.py
+++ b/gh_release_install/cli.py
@@ -71,8 +71,10 @@ def run(
         shfmt_{tag}_linux_amd64
         prometheus-{version}.linux-amd64.tar.gz
 
-    The DESTINATION argument define the DESTINATION path for the downloaded file.
-    Note that DESTINATION may contain variables such as '{version}' or '{tag}'.
+    The DESTINATION argument define the DESTINATION path for the downloaded
+    file. If DESTINATION is a directory, then the asset name will be written as
+    the file name in the directory. Note that DESTINATION may contain variables
+    such as '{version}' or '{tag}'.
 
     \b
     Examples:

--- a/gh_release_install/cli.py
+++ b/gh_release_install/cli.py
@@ -101,7 +101,9 @@ def run(
     To track the version installed on the system, use the --version-file flag to
     define the <filename> where the version should be saved.
     The default is not to save this version file.
-    Note that <filename> may contain variables such as '{destination}'.
+    Note that <filename> may contain variables such as '{destination}'. Also
+    note that '{destination}' is the full path, including filename, to the
+    asset (even if DESTINATION provided in the commandline is a directory).
 
     \b
     Examples:

--- a/gh_release_install/main.py
+++ b/gh_release_install/main.py
@@ -75,7 +75,12 @@ class GhReleaseInstall:
 
     @template_property
     def destination(self) -> Path:
-        return Path(self._format_tmpl(self._tmpls["destination"]))
+        destination = Path(self._format_tmpl(self._tmpls["destination"]))
+
+        if destination.is_dir():
+            return destination / self.asset
+
+        return destination
 
     @template_property
     def extract(self) -> Optional[str]:
@@ -173,13 +178,10 @@ class GhReleaseInstall:
                 asset_file = self._extract_release_asset(tmp_dir, asset_file)
                 Log.debug(f"Extracted archive to '{asset_file}'.")
 
-            destination_path = self.destination
-            if destination_path.is_dir():
-                destination_path = destination_path / asset_file.name
             Log.info("Installing file...")
-            move(asset_file, destination_path)
-            destination_path.chmod(0o755)
-            Log.debug(f"Installed file to '{destination_path}'.")
+            move(asset_file, self.destination)
+            self.destination.chmod(0o755)
+            Log.debug(f"Installed file to '{self.destination}'.")
 
         # Save to local tag/version file
         if self.version_file is not None:

--- a/gh_release_install/main.py
+++ b/gh_release_install/main.py
@@ -173,10 +173,13 @@ class GhReleaseInstall:
                 asset_file = self._extract_release_asset(tmp_dir, asset_file)
                 Log.debug(f"Extracted archive to '{asset_file}'.")
 
+            destination_path = self.destination
+            if destination_path.is_dir():
+                destination_path = destination_path / asset_file.name
             Log.info("Installing file...")
-            move(asset_file, self.destination)
-            self.destination.chmod(0o755)
-            Log.debug(f"Installed file to '{self.destination}'.")
+            move(asset_file, destination_path)
+            destination_path.chmod(0o755)
+            Log.debug(f"Installed file to '{destination_path}'.")
 
         # Save to local tag/version file
         if self.version_file is not None:


### PR DESCRIPTION
If DESTINATION is set as a directory, we should install the asset to the
directory with the asset name. This change adds support for such operations. We
also add a test case for installing to directories.

Tested:
  make test
  make e2e

Fixes jooola/gh-release-install#20