### PR TITLE
fix: unlink destination before replacing the it

### DIFF
--- a/gh_release_install/main.py
+++ b/gh_release_install/main.py
@@ -222,6 +222,9 @@ class GhReleaseInstall:
                 asset_file = self._extract_release_asset(tmp_dir, asset_file)
                 logger.info("Extracted archive to '%s'", asset_file)
 
+            if self.destination.is_file():
+                self.destination.unlink()
+
             move(asset_file, self.destination)
             self.destination.chmod(0o755)
             logger.info("Installed file to '%s'", self.destination)


### PR DESCRIPTION
This should prevent hitting `[Errno 26] Text file busy: '/usr/local/bin/promtail'` while trying to replace the destination file.

BEGIN_COMMIT_OVERRIDE
fix: unlink destination before replacing it (#220)
END_COMMIT_OVERRIDE